### PR TITLE
Improve manifest.json path handling in mod_manager.sh

### DIFF
--- a/OsxModManager/README.md
+++ b/OsxModManager/README.md
@@ -44,8 +44,9 @@ To run the script, you need the following installed and available on the command
 * curl
 * jq
 * bash version 4.0 or later (The default bash on macOS is v3.5, so you will need to install a newer version)
+* coreutils
 
-The easiest way to ensure this is to install [Homebrew](https://brew.sh/) and then run: `brew install curl jq bash`
+The easiest way to ensure this is to install [Homebrew](https://brew.sh/) and then run: `brew install curl jq bash coreutils`
 Note that bash will not overwrite the default macos version. I'm writing this from my windows computer and can't 
 remeber exactly where the default bash is located (`/bin/bash` or similar), the new one will be installed under `/opt/homebrew/bin`.
 
@@ -81,8 +82,10 @@ The selection is saved between runs.
 
 You can also press `p` or `enter` to start the game (with or without modpack), or `q` to exit the script.
 
-When installing a modpack, you will be prompted to enter the URL of the modpack on thunderstore.io. This is in the format https://thunderstore.io/c/valheim/p/Suudo/SweetAroma/
-You can also point to a local file that conforms to the manifest.json format.
+When installing a modpack, you can:
+- Enter a Thunderstore URL (e.g., https://thunderstore.io/c/valheim/p/Suudo/SweetAroma/).
+- Enter a local path to manifest.json (e.g., folder1/folder2/manifest.json).
+- Drag and drop the manifest.json file into the Terminal window.
 
 When installing client mods, you will be prompted to enter the dependency string of the mod on thunderstore.io, with or without a version number. 
 For example `oathorse-TubaWalk-0.1.3` or `oathorse-TubaWalk` (a mod which should be part of the actual game btw.)

--- a/OsxModManager/scripts/mod_manager.sh
+++ b/OsxModManager/scripts/mod_manager.sh
@@ -342,8 +342,7 @@ get_modpack_by_number() {
 }
 
 add_modpack_from_url_or_local() {
-    read -rp "Enter URL or local path to manifest.json: " input
-
+    read -rp "Enter URL or local path to manifest.json (or drag file onto Terminal): " input
     if [[ -z "$input" ]]; then
         echo "❌ No input entered."
         return
@@ -352,6 +351,15 @@ add_modpack_from_url_or_local() {
     local manifest_content=""
     local is_api_manifest=0
 
+    # Normalize the input path (handle escaped spaces, resolve relative paths)
+    if [[ ! "$input" =~ ^https?:// ]] && [[ ! "$input" =~ ^/ ]]; then
+        # Relative path: resolve relative to SCRIPT_ROOT
+        input="$SCRIPT_ROOT/$input"
+    fi
+    # Convert escaped spaces (\ ) to regular spaces and resolve to absolute path
+    input=$(echo "$input" | sed 's/\\ / /g')
+    input=$(realpath "$input" 2>/dev/null || echo "$input")
+
     if [[ -f "$input" ]]; then
         # Local file path
         manifest_content=$(cat "$input")
@@ -359,11 +367,11 @@ add_modpack_from_url_or_local() {
         # URL
         local url=$input
         if [[ "$url" =~ /p/([^/]+)/([^/]+)/?$ ]]; then
-          author="${BASH_REMATCH[1]}"
-          modname="${BASH_REMATCH[2]}"
+            author="${BASH_REMATCH[1]}"
+            modname="${BASH_REMATCH[2]}"
         else
-          echo "❌ Invalid Thunderstore URL format."
-          return
+            echo "❌ Invalid Thunderstore URL format."
+            return
         fi
         api_url="https://thunderstore.io/api/experimental/package/${author}/${modname}/"
         if ! manifest_content=$(curl -fsSL "$api_url"); then
@@ -372,7 +380,7 @@ add_modpack_from_url_or_local() {
         fi
         is_api_manifest=1
     else
-        echo "❌ Input is neither a file nor a valid URL."
+        echo "❌ Input is neither a valid file nor a URL: $input"
         return
     fi
 


### PR DESCRIPTION
Modified `add_modpack_from_url_or_local` in `mod_manager.sh` to:
- Handle drag-and-drop paths with escaped spaces.
- Resolve relative paths relative to `SCRIPT_ROOT`.
- Use `realpath` for path normalization (requires `coreutils`).

This fixes issues with `manifest.json` not being found when using relative or dragged paths. Also added suggestion to install coreutils in README.